### PR TITLE
Potential fix for code scanning alert no. 1: Unbounded write

### DIFF
--- a/sample.c
+++ b/sample.c
@@ -2,6 +2,6 @@
 int main() {
 	char last_name[20];
 	printf ("Enter your last name: ");
-	scanf ("%s", last_name);
+	scanf ("%19s", last_name);
 	printf("Entered last name is %s\n", last_name);
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Mattf-85/MF85/security/code-scanning/1](https://github.com/Mattf-85/MF85/security/code-scanning/1)

To fix the problem, we need to ensure that the input read by `scanf` does not exceed the size of the buffer. This can be achieved by specifying a maximum field width in the `scanf` format string, which limits the number of characters read. In this case, we should limit the input to 19 characters to leave space for the null terminator.

The best way to fix the problem without changing existing functionality is to modify the `scanf` call to include a field width specifier. This change should be made in the `sample.c` file, specifically on line 5.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
